### PR TITLE
Push image to Google Container Registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+# Reference: https://github.com/mozilla/pensieve/blob/master/.circleci/config.yml
+version: 2.1
+
+# See https://circleci.com/orbs/registry/orb/circleci/gcp-gcr
+orbs:
+  gcp-gcr: circleci/gcp-gcr@0.6.1
+
+workflows:
+  build-and-deploy:
+    jobs:
+      - gcp-gcr/build-and-push-image:
+          image: probe-search
+          filters:
+            branches:
+              only:
+                - master

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN pip install -U pip \
 # END: BUILD IMAGE
 
 # BEGIN: FINAL IMAGE
-FROM python-3.8-slim AS final
+FROM python:3.8-slim AS final
 WORKDIR /app
 COPY --from=backend /venv/ /venv/
 CMD ["python", "-m", "probe_search.import"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN pip install -U pip \
 # BEGIN: FINAL IMAGE
 FROM python:3.8-slim AS final
 WORKDIR /app
+ENV PATH="/venv/bin:$PATH"
 COPY --from=backend /venv/ /venv/
+COPY ./probe_search probe_search
+
 CMD ["python", "-m", "probe_search.import"]
 # END: FINAL IMAGE


### PR DESCRIPTION
This fixes the dockerfile so it runs correctly, which can be tested as follows:

```bash
docker build -t probe-search .
docker run probe-search
```

This also pushes the image to GCR. I have this set up on my fork's master branch using the `glam-fenix-dev` project. I followed this cookbook: https://docs.telemetry.mozilla.org/cookbooks/deploying-containers.html

This is available for testing locally using `docker run gcr.io/glam-fenix-dev/probe-search`. The cookbook will need to be followed using the project associated with this repo. 