### PR TITLE
Add `active` property for desktop probes

### DIFF
--- a/probes/management/commands/import_telemetry.py
+++ b/probes/management/commands/import_telemetry.py
@@ -34,6 +34,7 @@ class Command(BaseCommand):
 
             # Add a calculated property for info we calculate from the probeinfo data.
             calculated = {
+                "active": name in processes,
                 "seen_in_processes": processes.get(name, []),
                 "latest_history": history,
             }


### PR DESCRIPTION
We are defining "active" as probes seen by Glam in last 3 versions.